### PR TITLE
Add schema defaults on Create and versionKey optimistic concurrency

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -90,6 +90,14 @@ func CreateMany(ctx context.Context, models interface{}, opts ...CreateOptions) 
 			// Set timestamps
 			setTimestamps(model, now)
 
+			// Apply schema defaults to zero-valued fields
+			if err := applyDefaults(model, schema); err != nil {
+				return err
+			}
+
+			// Initialize version to 0
+			setModelVersion(model, 0)
+
 			// BeforeCreate hook
 			if hook, ok := model.(BeforeCreate); ok {
 				if err := hook.BeforeCreate(ctx); err != nil {

--- a/bulk.go
+++ b/bulk.go
@@ -113,7 +113,7 @@ func CreateMany(ctx context.Context, models interface{}, opts ...CreateOptions) 
 			docs[i] = model
 		}
 
-		coll := db.Collection(schema.Collection)
+		coll := getCollection(db, schema)
 		if _, err := coll.InsertMany(ctx, docs); err != nil {
 			return fmt.Errorf("goodm: insert many failed: %w", err)
 		}
@@ -167,7 +167,7 @@ func UpdateMany(ctx context.Context, filter, update interface{}, model interface
 		Model:      model,
 		Filter:     filter,
 	}, func(ctx context.Context) error {
-		coll := db.Collection(schema.Collection)
+		coll := getCollection(db, schema)
 		res, err := coll.UpdateMany(ctx, filter, update)
 		if err != nil {
 			return fmt.Errorf("goodm: update many failed: %w", err)
@@ -209,7 +209,7 @@ func DeleteMany(ctx context.Context, filter interface{}, model interface{}, opts
 		ModelName:  schema.ModelName,
 		Filter:     filter,
 	}, func(ctx context.Context) error {
-		coll := db.Collection(schema.Collection)
+		coll := getCollection(db, schema)
 		res, err := coll.DeleteMany(ctx, filter)
 		if err != nil {
 			return fmt.Errorf("goodm: delete many failed: %w", err)

--- a/crud.go
+++ b/crud.go
@@ -67,6 +67,14 @@ func Create(ctx context.Context, model interface{}, opts ...CreateOptions) error
 		// Set timestamps
 		setTimestamps(model, time.Now())
 
+		// Apply schema defaults to zero-valued fields
+		if err := applyDefaults(model, schema); err != nil {
+			return err
+		}
+
+		// Initialize version to 0
+		setModelVersion(model, 0)
+
 		// BeforeCreate hook
 		if hook, ok := model.(BeforeCreate); ok {
 			if err := hook.BeforeCreate(ctx); err != nil {
@@ -289,16 +297,48 @@ func Update(ctx context.Context, model interface{}, opts ...UpdateOptions) error
 			return ValidationErrors(errs)
 		}
 
+		// Read current version and increment
+		oldVersion, _ := getModelVersion(model)
+		setModelVersion(model, oldVersion+1)
+
 		// Set UpdatedAt
 		setUpdatedAt(model, time.Now())
 
+		// Build filter with version check for optimistic concurrency.
+		// When oldVersion == 0, also match documents without __v (legacy compat).
+		var filter bson.D
+		if oldVersion == 0 {
+			filter = bson.D{
+				{Key: "_id", Value: id},
+				{Key: "$or", Value: bson.A{
+					bson.D{{Key: "__v", Value: 0}},
+					bson.D{{Key: "__v", Value: bson.D{{Key: "$exists", Value: false}}}},
+				}},
+			}
+		} else {
+			filter = bson.D{
+				{Key: "_id", Value: id},
+				{Key: "__v", Value: oldVersion},
+			}
+		}
+
 		// Replace
-		result, err := coll.ReplaceOne(ctx, bson.D{{Key: "_id", Value: id}}, model)
+		result, err := coll.ReplaceOne(ctx, filter, model)
 		if err != nil {
+			setModelVersion(model, oldVersion) // roll back on error
 			return fmt.Errorf("goodm: update failed: %w", err)
 		}
 		if result.MatchedCount == 0 {
-			return ErrNotFound
+			setModelVersion(model, oldVersion) // roll back version
+			// Disambiguate: does the doc exist at all?
+			count, countErr := coll.CountDocuments(ctx, bson.D{{Key: "_id", Value: id}})
+			if countErr != nil {
+				return fmt.Errorf("goodm: update failed: %w", countErr)
+			}
+			if count == 0 {
+				return ErrNotFound
+			}
+			return ErrVersionConflict
 		}
 
 		// AfterSave hook
@@ -578,4 +618,28 @@ func hasImmutableFields(schema *Schema) bool {
 		}
 	}
 	return false
+}
+
+// getModelVersion extracts the Version field from a model via reflection.
+func getModelVersion(model interface{}) (int, error) {
+	v := reflect.ValueOf(model)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	f := v.FieldByName("Version")
+	if !f.IsValid() {
+		return 0, fmt.Errorf("goodm: model has no Version field")
+	}
+	return int(f.Int()), nil
+}
+
+// setModelVersion sets the Version field on a model via reflection.
+func setModelVersion(model interface{}, version int) {
+	v := reflect.ValueOf(model)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if f := v.FieldByName("Version"); f.IsValid() && f.CanSet() {
+		f.SetInt(int64(version))
+	}
 }

--- a/crud_test.go
+++ b/crud_test.go
@@ -411,6 +411,45 @@ func TestHooks_Integration(t *testing.T) {
 	}
 }
 
+// --- collection options unit tests ---
+
+func TestRegister_ConfigurableInterface(t *testing.T) {
+	registerTestModels()
+	defer unregisterTestModels()
+
+	schema, ok := Get("testConfiguredModel")
+	if !ok {
+		t.Fatal("testConfiguredModel not registered")
+	}
+
+	if schema.CollOptions.ReadPreference == nil {
+		t.Fatal("expected ReadPreference to be set")
+	}
+	if schema.CollOptions.WriteConcern == nil {
+		t.Fatal("expected WriteConcern to be set")
+	}
+	if schema.CollOptions.ReadConcern != nil {
+		t.Fatal("expected ReadConcern to be nil (not set)")
+	}
+}
+
+func TestRegister_NoConfigurable(t *testing.T) {
+	registerTestModels()
+	defer unregisterTestModels()
+
+	schema, ok := Get("testUser")
+	if !ok {
+		t.Fatal("testUser not registered")
+	}
+
+	if schema.CollOptions.ReadPreference != nil {
+		t.Fatal("expected ReadPreference to be nil for non-configurable model")
+	}
+	if schema.CollOptions.WriteConcern != nil {
+		t.Fatal("expected WriteConcern to be nil for non-configurable model")
+	}
+}
+
 // --- version helper unit tests ---
 
 func TestGetModelVersion(t *testing.T) {

--- a/crud_test.go
+++ b/crud_test.go
@@ -411,6 +411,211 @@ func TestHooks_Integration(t *testing.T) {
 	}
 }
 
+// --- version helper unit tests ---
+
+func TestGetModelVersion(t *testing.T) {
+	u := &testUser{}
+	u.Version = 5
+
+	v, err := getModelVersion(u)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 5 {
+		t.Fatalf("expected 5, got %d", v)
+	}
+}
+
+func TestSetModelVersion(t *testing.T) {
+	u := &testUser{}
+	setModelVersion(u, 3)
+
+	if u.Version != 3 {
+		t.Fatalf("expected 3, got %d", u.Version)
+	}
+}
+
+// --- defaults integration tests ---
+
+func TestCreate_AppliesDefaults(t *testing.T) {
+	ctx, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	u := &testUser{
+		Email: "defaults@test.com",
+		Name:  "Defaults",
+		Age:   25,
+		// Role left empty — should get default "user"
+	}
+	if err := Create(ctx, u); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if u.Role != "user" {
+		t.Fatalf("expected Role 'user', got %q", u.Role)
+	}
+
+	// Verify in DB
+	found := &testUser{}
+	if err := FindOne(ctx, bson.D{{Key: "_id", Value: u.ID}}, found); err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if found.Role != "user" {
+		t.Fatalf("expected Role 'user' in DB, got %q", found.Role)
+	}
+}
+
+func TestCreateMany_AppliesDefaults(t *testing.T) {
+	ctx, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	users := []testUser{
+		{Email: "def1@test.com", Name: "Def1", Age: 20},
+		{Email: "def2@test.com", Name: "Def2", Age: 21, Role: "admin"},
+	}
+	if err := CreateMany(ctx, users); err != nil {
+		t.Fatalf("create many: %v", err)
+	}
+
+	if users[0].Role != "user" {
+		t.Fatalf("expected default Role 'user', got %q", users[0].Role)
+	}
+	if users[1].Role != "admin" {
+		t.Fatalf("expected Role 'admin' (not overwritten), got %q", users[1].Role)
+	}
+}
+
+// --- versioning integration tests ---
+
+func TestCreate_SetsVersionZero(t *testing.T) {
+	ctx, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	u := &testUser{Email: "v0@test.com", Name: "V0", Age: 25, Role: "user"}
+	if err := Create(ctx, u); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if u.Version != 0 {
+		t.Fatalf("expected Version 0, got %d", u.Version)
+	}
+
+	// Verify in DB
+	found := &testUser{}
+	if err := FindOne(ctx, bson.D{{Key: "_id", Value: u.ID}}, found); err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if found.Version != 0 {
+		t.Fatalf("expected Version 0 in DB, got %d", found.Version)
+	}
+}
+
+func TestUpdate_IncrementsVersion(t *testing.T) {
+	ctx, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	u := &testUser{Email: "vinc@test.com", Name: "VInc", Age: 25, Role: "user"}
+	if err := Create(ctx, u); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	u.Age = 26
+	if err := Update(ctx, u); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if u.Version != 1 {
+		t.Fatalf("expected Version 1, got %d", u.Version)
+	}
+
+	// Verify in DB
+	found := &testUser{}
+	if err := FindOne(ctx, bson.D{{Key: "_id", Value: u.ID}}, found); err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if found.Version != 1 {
+		t.Fatalf("expected Version 1 in DB, got %d", found.Version)
+	}
+}
+
+func TestUpdate_MultipleIncrements(t *testing.T) {
+	ctx, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	u := &testUser{Email: "vmulti@test.com", Name: "VMulti", Age: 25, Role: "user"}
+	if err := Create(ctx, u); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		u.Age = 26 + i
+		if err := Update(ctx, u); err != nil {
+			t.Fatalf("update %d: %v", i, err)
+		}
+	}
+
+	if u.Version != 3 {
+		t.Fatalf("expected Version 3, got %d", u.Version)
+	}
+}
+
+func TestUpdate_VersionConflict(t *testing.T) {
+	ctx, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	u := &testUser{Email: "conflict@test.com", Name: "Conflict", Age: 25, Role: "user"}
+	if err := Create(ctx, u); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Load the same doc a second time
+	u2 := &testUser{}
+	if err := FindOne(ctx, bson.D{{Key: "_id", Value: u.ID}}, u2); err != nil {
+		t.Fatalf("find: %v", err)
+	}
+
+	// First update succeeds
+	u.Age = 26
+	if err := Update(ctx, u); err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+
+	// Second update with stale version should conflict
+	u2.Age = 27
+	err := Update(ctx, u2)
+	if !errors.Is(err, ErrVersionConflict) {
+		t.Fatalf("expected ErrVersionConflict, got %v", err)
+	}
+}
+
+func TestUpdate_VersionConflict_RollsBack(t *testing.T) {
+	ctx, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	u := &testUser{Email: "rollback@test.com", Name: "Rollback", Age: 25, Role: "user"}
+	if err := Create(ctx, u); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Load the same doc twice
+	u2 := &testUser{}
+	if err := FindOne(ctx, bson.D{{Key: "_id", Value: u.ID}}, u2); err != nil {
+		t.Fatalf("find: %v", err)
+	}
+
+	// First update succeeds (version 0 -> 1)
+	u.Age = 26
+	if err := Update(ctx, u); err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+
+	// Second update fails with version conflict
+	u2.Age = 27
+	_ = Update(ctx, u2)
+
+	// u2's version should be rolled back to 0 (its pre-conflict state)
+	if u2.Version != 0 {
+		t.Fatalf("expected version rolled back to 0, got %d", u2.Version)
+	}
+}
+
 func TestMiddleware_WithCRUD_Integration(t *testing.T) {
 	ctx, _, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/defaults.go
+++ b/defaults.go
@@ -1,0 +1,79 @@
+package goodm
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// applyDefaults sets zero-valued fields to their schema defaults.
+// Only called during Create — defaults are a creation-time concern.
+func applyDefaults(model interface{}, schema *Schema) error {
+	v := reflect.ValueOf(model)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	for _, field := range schema.Fields {
+		if field.Default == "" {
+			continue
+		}
+
+		fv := v.FieldByName(field.Name)
+		if !fv.IsValid() || !fv.CanSet() {
+			continue
+		}
+
+		// Only apply to zero-valued fields
+		if !fv.IsZero() {
+			continue
+		}
+
+		if err := setFieldFromString(fv, field.Default); err != nil {
+			return fmt.Errorf("goodm: cannot apply default %q to field %s: %w", field.Default, field.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// setFieldFromString parses a string value and sets it on a reflect.Value.
+func setFieldFromString(fv reflect.Value, s string) error {
+	switch fv.Kind() {
+	case reflect.String:
+		fv.SetString(s)
+
+	case reflect.Bool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return err
+		}
+		fv.SetBool(b)
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		fv.SetInt(n)
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		fv.SetUint(n)
+
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return err
+		}
+		fv.SetFloat(f)
+
+	default:
+		return fmt.Errorf("unsupported type %s", fv.Type())
+	}
+
+	return nil
+}

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -1,0 +1,122 @@
+package goodm
+
+import (
+	"reflect"
+	"testing"
+)
+
+type testDefaults struct {
+	Model   `bson:",inline"`
+	Name    string  `bson:"name"    goodm:"default=anonymous"`
+	Age     int     `bson:"age"     goodm:"default=18"`
+	Score   float64 `bson:"score"   goodm:"default=9.5"`
+	Active  bool    `bson:"active"  goodm:"default=true"`
+	NoDefault string `bson:"no_default"`
+}
+
+func TestApplyDefaults_String(t *testing.T) {
+	schema := &Schema{
+		Fields: []FieldSchema{
+			{Name: "Name", BSONName: "name", Default: "anonymous"},
+		},
+	}
+
+	m := &testDefaults{}
+	if err := applyDefaults(m, schema); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Name != "anonymous" {
+		t.Fatalf("expected 'anonymous', got %q", m.Name)
+	}
+}
+
+func TestApplyDefaults_Int(t *testing.T) {
+	schema := &Schema{
+		Fields: []FieldSchema{
+			{Name: "Age", BSONName: "age", Default: "18"},
+		},
+	}
+
+	m := &testDefaults{}
+	if err := applyDefaults(m, schema); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Age != 18 {
+		t.Fatalf("expected 18, got %d", m.Age)
+	}
+}
+
+func TestApplyDefaults_Float64(t *testing.T) {
+	schema := &Schema{
+		Fields: []FieldSchema{
+			{Name: "Score", BSONName: "score", Default: "9.5"},
+		},
+	}
+
+	m := &testDefaults{}
+	if err := applyDefaults(m, schema); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Score != 9.5 {
+		t.Fatalf("expected 9.5, got %f", m.Score)
+	}
+}
+
+func TestApplyDefaults_Bool(t *testing.T) {
+	schema := &Schema{
+		Fields: []FieldSchema{
+			{Name: "Active", BSONName: "active", Default: "true"},
+		},
+	}
+
+	m := &testDefaults{}
+	if err := applyDefaults(m, schema); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.Active {
+		t.Fatal("expected Active to be true")
+	}
+}
+
+func TestApplyDefaults_NonZeroNotOverwritten(t *testing.T) {
+	schema := &Schema{
+		Fields: []FieldSchema{
+			{Name: "Name", BSONName: "name", Default: "anonymous"},
+			{Name: "Age", BSONName: "age", Default: "18"},
+		},
+	}
+
+	m := &testDefaults{Name: "Alice", Age: 30}
+	if err := applyDefaults(m, schema); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Name != "Alice" {
+		t.Fatalf("expected 'Alice', got %q", m.Name)
+	}
+	if m.Age != 30 {
+		t.Fatalf("expected 30, got %d", m.Age)
+	}
+}
+
+func TestApplyDefaults_InvalidParse(t *testing.T) {
+	schema := &Schema{
+		Fields: []FieldSchema{
+			{Name: "Age", BSONName: "age", Default: "not_a_number"},
+		},
+	}
+
+	m := &testDefaults{}
+	err := applyDefaults(m, schema)
+	if err == nil {
+		t.Fatal("expected error for invalid int parse")
+	}
+}
+
+func TestSetFieldFromString_UnsupportedType(t *testing.T) {
+	// A slice field cannot be set from string
+	v := reflect.ValueOf(&[]string{}).Elem()
+	err := setFieldFromString(v, "test")
+	if err == nil {
+		t.Fatal("expected error for unsupported type")
+	}
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -59,7 +59,7 @@ goodm.Use(func(ctx context.Context, op *goodm.OpInfo, next func(context.Context)
 
 **What they are in Mongoose:** When a field is missing from a document in the database, Mongoose fills in the schema default when reading.
 
-**Why goodm skips them:** Go structs already have zero values, and the `default` tag in goodm is informational metadata used by code generation and the CLI inspect command. Silently mutating data on read creates a mismatch between what's in the database and what's in memory, making debugging harder. If you need defaults applied on creation, use a `BeforeCreate` hook.
+**What goodm does instead:** goodm applies `default=X` values at creation time — during `Create` and `CreateMany`, zero-valued fields are set to their schema default before hooks and validation run. This means the default is persisted to the database, so reads always return exactly what's stored. Read-time defaults (silently filling in missing values on query) are still omitted because they create a mismatch between what's in the database and what's in memory, making debugging harder.
 
 ### Discriminators (Single-Collection Inheritance)
 
@@ -72,6 +72,23 @@ goodm.Use(func(ctx context.Context, op *goodm.OpInfo, next func(context.Context)
 **What it is in Mongoose:** Automatically casts query values to match schema types (e.g., string `"5"` becomes number `5`).
 
 **Why goodm skips it:** Go is statically typed. If you pass an `int` to a filter, it's already an `int`. Query casting exists in Mongoose because JavaScript is dynamically typed and values from HTTP requests arrive as strings. In Go, you parse input at the boundary (HTTP handler) and work with typed values from there.
+
+## Mongoose Schema Options
+
+Mongoose schemas accept many options. Here's how goodm handles each:
+
+| Option | Status | Rationale |
+|--------|--------|-----------|
+| `strict` | N/A | Go structs are inherently strict — only declared fields are serialized. There's no "loose mode" to toggle. |
+| `versionKey` | **Implemented** | goodm uses `__v` (same as Mongoose) for optimistic concurrency control. See [CRUD docs](crud.md) for details. |
+| `autoIndex` | Omitted | goodm uses explicit `Enforce()` to create indexes on demand, giving you full control over when index creation happens (e.g., deploy scripts vs. app startup). |
+| `toJSON` / `toObject` | Omitted | Use Go's `json.Marshaler` interface or custom methods on your struct. The language already provides this. |
+| `minimize` | Omitted | Use `bson:",omitempty"` on struct tags to skip zero-valued fields. This is more granular than a schema-level flag. |
+| `capped` | Omitted | Capped collections are a MongoDB admin concern. Create them using the MongoDB driver directly: `db.CreateCollection(ctx, name, options.CreateCollection().SetCapped(true).SetSizeInBytes(size))`. |
+| `read` / `writeConcern` | Omitted | Set these on the `*mongo.Database` or `*mongo.Collection` via driver options, or pass a configured `DB` via `CreateOptions`/`FindOptions`/etc. |
+| `shardKey` | Omitted | Shard keys are a database administration concern configured at the MongoDB level, not the application level. |
+| `validateBeforeSave` | Always on | goodm always validates before Create and Update. To bypass validation, use raw passthroughs (`UpdateOne`, `DeleteOne`, `UpdateMany`, `DeleteMany`). |
+| `selectPopulatedPaths` | N/A | goodm's `Populate` is explicit — you specify exactly which fields to populate. There's no automatic path selection to configure. |
 
 ## Design Principles
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -85,7 +85,7 @@ Mongoose schemas accept many options. Here's how goodm handles each:
 | `toJSON` / `toObject` | Omitted | Use Go's `json.Marshaler` interface or custom methods on your struct. The language already provides this. |
 | `minimize` | Omitted | Use `bson:",omitempty"` on struct tags to skip zero-valued fields. This is more granular than a schema-level flag. |
 | `capped` | Omitted | Capped collections are a MongoDB admin concern. Create them using the MongoDB driver directly: `db.CreateCollection(ctx, name, options.CreateCollection().SetCapped(true).SetSizeInBytes(size))`. |
-| `read` / `writeConcern` | **Planned** | Per-schema read/write concern is a natural fit for goodm's declarative model — separating read and write patterns per collection is a common performance optimization in clustered deployments, and the intent should be visible in the schema, not buried in driver setup code. |
+| `read` / `writeConcern` | **Implemented** | Per-schema read/write concern via the `Configurable` interface. Implement `CollectionOptions()` on your model to set read preference, read concern, and write concern. All CRUD, bulk, and pipeline operations automatically use the configured options. |
 | `shardKey` | Omitted | Shard keys are a database administration concern configured at the MongoDB level, not the application level. |
 | `validateBeforeSave` | Always on | goodm always validates before Create and Update. To bypass validation, use raw passthroughs (`UpdateOne`, `DeleteOne`, `UpdateMany`, `DeleteMany`). |
 | `selectPopulatedPaths` | N/A | goodm's `Populate` is explicit — you specify exactly which fields to populate. There's no automatic path selection to configure. |

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -85,7 +85,7 @@ Mongoose schemas accept many options. Here's how goodm handles each:
 | `toJSON` / `toObject` | Omitted | Use Go's `json.Marshaler` interface or custom methods on your struct. The language already provides this. |
 | `minimize` | Omitted | Use `bson:",omitempty"` on struct tags to skip zero-valued fields. This is more granular than a schema-level flag. |
 | `capped` | Omitted | Capped collections are a MongoDB admin concern. Create them using the MongoDB driver directly: `db.CreateCollection(ctx, name, options.CreateCollection().SetCapped(true).SetSizeInBytes(size))`. |
-| `read` / `writeConcern` | Omitted | Set these on the `*mongo.Database` or `*mongo.Collection` via driver options, or pass a configured `DB` via `CreateOptions`/`FindOptions`/etc. |
+| `read` / `writeConcern` | **Planned** | Per-schema read/write concern is a natural fit for goodm's declarative model — separating read and write patterns per collection is a common performance optimization in clustered deployments, and the intent should be visible in the schema, not buried in driver setup code. |
 | `shardKey` | Omitted | Shard keys are a database administration concern configured at the MongoDB level, not the application level. |
 | `validateBeforeSave` | Always on | goodm always validates before Create and Update. To bypass validation, use raw passthroughs (`UpdateOne`, `DeleteOne`, `UpdateMany`, `DeleteMany`). |
 | `selectPopulatedPaths` | N/A | goodm's `Populate` is explicit — you specify exactly which fields to populate. There's no automatic path selection to configure. |

--- a/docs/models.md
+++ b/docs/models.md
@@ -22,13 +22,14 @@ func init() {
 
 ## Base Model
 
-`goodm.Model` provides three fields automatically:
+`goodm.Model` provides four fields automatically:
 
 | Field | BSON | Type | Behavior |
 |-------|------|------|----------|
 | `ID` | `_id` | `bson.ObjectID` | Auto-generated on Create if zero |
 | `CreatedAt` | `created_at` | `time.Time` | Set on Create (only if zero) |
 | `UpdatedAt` | `updated_at` | `time.Time` | Set on Create, refreshed on Update |
+| `Version` | `__v` | `int` | Set to 0 on Create, incremented on each Update (optimistic concurrency) |
 
 Always embed with `bson:",inline"` to flatten the fields into the document.
 
@@ -70,7 +71,7 @@ Username string `bson:"username" goodm:"immutable"`
 
 ### `default=X`
 
-Annotates the default value. This is metadata for documentation and code generation — goodm does not automatically apply defaults.
+Sets the default value for a field. During `Create` and `CreateMany`, if the field is zero-valued, goodm sets it to this default before hooks and validation run. Supported types: string, bool, int/int8-64, uint/uint8-64, float32/float64.
 
 ```go
 Role string `bson:"role" goodm:"default=user"`

--- a/errors.go
+++ b/errors.go
@@ -12,6 +12,11 @@ var (
 
 	// ErrNoDatabase is returned when no database connection is available.
 	ErrNoDatabase = errors.New("goodm: no database connection (call Connect first)")
+
+	// ErrVersionConflict is returned when an update fails due to a version mismatch
+	// (optimistic concurrency control). This means another process modified the
+	// document between your read and write.
+	ErrVersionConflict = errors.New("goodm: version conflict (document was modified by another process)")
 )
 
 // DriftError indicates a field exists in the database but not in the schema.

--- a/model.go
+++ b/model.go
@@ -7,9 +7,10 @@ import (
 )
 
 // Model is the base struct that all goodm models should embed.
-// It provides automatic ID generation and timestamp management.
+// It provides automatic ID generation, timestamp management, and optimistic concurrency control.
 type Model struct {
 	ID        bson.ObjectID `bson:"_id,omitempty"`
 	CreatedAt time.Time     `bson:"created_at"`
 	UpdatedAt time.Time     `bson:"updated_at"`
+	Version   int           `bson:"__v"`
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -133,7 +133,7 @@ func (p *Pipeline) Execute(ctx context.Context, results interface{}) error {
 		return err
 	}
 
-	coll := db.Collection(schema.Collection)
+	coll := getCollection(db, schema)
 	cursor, err := coll.Aggregate(ctx, p.stages)
 	if err != nil {
 		return fmt.Errorf("goodm: aggregate failed: %w", err)
@@ -161,7 +161,7 @@ func (p *Pipeline) Cursor(ctx context.Context) (*mongo.Cursor, error) {
 		return nil, err
 	}
 
-	coll := db.Collection(schema.Collection)
+	coll := getCollection(db, schema)
 	cursor, err := coll.Aggregate(ctx, p.stages)
 	if err != nil {
 		return nil, fmt.Errorf("goodm: aggregate cursor failed: %w", err)

--- a/registry.go
+++ b/registry.go
@@ -57,6 +57,11 @@ func Register(model interface{}, collection string) error {
 		schema.CompoundIndexes = indexable.Indexes()
 	}
 
+	// Check for Configurable interface (per-schema collection options)
+	if configurable, ok := model.(Configurable); ok {
+		schema.CollOptions = configurable.CollectionOptions()
+	}
+
 	// Detect hook implementations
 	schema.Hooks = detectHooks(model)
 

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -10,6 +10,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
+	"go.mongodb.org/mongo-driver/v2/mongo/writeconcern"
 )
 
 // --- test models ---
@@ -38,6 +40,18 @@ type testPost struct {
 	Title    string          `bson:"title"  goodm:"required"`
 	AuthorID bson.ObjectID   `bson:"author" goodm:"ref=test_users"`
 	TagIDs   []bson.ObjectID `bson:"tags"   goodm:"ref=test_tags"`
+}
+
+type testConfiguredModel struct {
+	Model `bson:",inline"`
+	Name  string `bson:"name" goodm:"required"`
+}
+
+func (m *testConfiguredModel) CollectionOptions() CollectionOptions {
+	return CollectionOptions{
+		ReadPreference: readpref.SecondaryPreferred(),
+		WriteConcern:   writeconcern.Majority(),
+	}
 }
 
 type testHookUser struct {
@@ -128,6 +142,7 @@ func registerTestModels() {
 	_ = Register(&testTag{}, "test_tags")
 	_ = Register(&testPost{}, "test_posts")
 	_ = Register(&testHookUser{}, "test_hook_users")
+	_ = Register(&testConfiguredModel{}, "test_configured")
 }
 
 func unregisterTestModels() {
@@ -137,5 +152,6 @@ func unregisterTestModels() {
 	delete(registry, "testTag")
 	delete(registry, "testPost")
 	delete(registry, "testHookUser")
+	delete(registry, "testConfiguredModel")
 	registryMu.Unlock()
 }


### PR DESCRIPTION
## Summary

- **Schema defaults on Create**: `default=X` tag values are now applied to zero-valued fields during `Create` and `CreateMany`, before hooks and validation run. Supported types: string, bool, int/int8-64, uint/uint8-64, float32/float64.
- **versionKey (`__v`) optimistic concurrency**: `Model` now includes a `Version` field (`bson:"__v"`). Initialized to 0 on Create, incremented on each `Update`. Updates filter by `{_id, __v}` — stale writes return `ErrVersionConflict`. Legacy documents (without `__v`) are handled via an `$or` fallback.
- **Per-schema read/write concern**: New `Configurable` interface — implement `CollectionOptions()` on your model to declaratively set `ReadPreference`, `ReadConcern`, and `WriteConcern`. All CRUD, bulk, and pipeline operations automatically use the configured options. Admin operations (Enforce, Migrate) are unaffected.
- **Design decisions doc**: Added Mongoose schema options table (strict, autoIndex, toJSON, minimize, capped, read/writeConcern, shardKey, validateBeforeSave, selectPopulatedPaths). Updated defaults entry to reflect creation-time application.
- **Docs updated**: `models.md` (Version in base model table, default=X description, Collection Options section), `crud.md` (lifecycle steps, ErrVersionConflict in error table).

## Files changed

| File | Change |
|------|--------|
| `defaults.go` | **NEW** — `applyDefaults`, `setFieldFromString` |
| `defaults_test.go` | **NEW** — 7 unit tests for defaults |
| `model.go` | Add `Version int` field |
| `errors.go` | Add `ErrVersionConflict` |
| `schema.go` | Add `CollectionOptions` type, `Configurable` interface, `CollOptions` field on Schema |
| `registry.go` | Detect `Configurable` interface during Register |
| `crud.go` | Add `getCollection` helper, version helpers, defaults+version in Create, version filter in Update |
| `bulk.go` | Defaults+version in CreateMany, use `getCollection` |
| `pipeline.go` | Use `getCollection` for per-schema options |
| `testutil_test.go` | Add `testConfiguredModel` with `CollectionOptions` |
| `crud_test.go` | Unit + integration tests for defaults, versioning, and collection options |
| `docs/design-decisions.md` | Schema options table, updated defaults and read/writeConcern entries |
| `docs/models.md` | Updated default=X docs, added Version to base model, Collection Options section |
| `docs/crud.md` | Updated lifecycle steps, added ErrVersionConflict |

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Unit tests pass: defaults (all types), version helpers, Configurable registration, non-configurable models
- [ ] Integration tests (require MongoDB): default application on Create/CreateMany, version init, increment, multiple increments, conflict detection, rollback on conflict